### PR TITLE
Added procedurally generated textures(Sinusoid normal map, Checkerboard, Worley Noise)

### DIFF
--- a/scenes/plane.json
+++ b/scenes/plane.json
@@ -1,5 +1,29 @@
 [
     {
+        "type": "texture",
+        "pattern": "bumpSine",
+        "name": "BumpSine",
+        "u_variation": 0.5,
+        "v_variation": 0.0
+    },
+    {
+        "type": "texture",
+        "pattern": "checkerboard",
+        "name": "CheckerBW",
+        "color_b": [255, 0, 0]
+    },
+    {
+        "type": "texture",
+        "pattern": "worley",
+        "name": "WorleyBW",
+        "dots": 30,
+        "color_a": [155, 0, 0],
+        "color_b": [0, 0, 180],
+        "res_x": 2000,
+        "res_y": 2000
+    },
+    
+    {
         "type": "sphere",
         "pos": [0, 0, -2],
         "dir": [0, 1, 0],
@@ -13,10 +37,12 @@
         "type": "sphere",
         "pos": [-2.5, 2.5, 2],
         "dir": [0, 1, 0],
-        "color": "bricks_color.jpg",
+        "color": [0, 0, 0],
         "radius": 2.0,
-        "normal": "bricks_normal.jpg",
-        "roughness": "bricks_roughness.jpg"
+        "normal": "BumpSine",
+        "roughness": "bricks_roughness.jpg",
+        "u_scale": 50,
+        "v_scale": 50
     },
     {
         "type": "sphere",
@@ -53,7 +79,7 @@
         "dir_w": [0, 0, 1],
         "length": 100,
         "width": 100,
-        "color": [255, 255, 255]
+        "color": "WorleyBW"
     },
 
     {

--- a/src/display/mainloop.rs
+++ b/src/display/mainloop.rs
@@ -24,7 +24,7 @@ pub fn load_scene(scene_path: &str, context: &mut UIContext, ui: &mut UI) {
         return ;
     }
     let mut scene = scene.unwrap();
-    scene.load_texture(SKYBOX_TEXTURE);
+    scene.load_texture(SKYBOX_TEXTURE, None);
     
     if DISPLAY_WIREFRAME {
         scene.add_wireframes();

--- a/src/model/materials/texture.rs
+++ b/src/model/materials/texture.rs
@@ -1,6 +1,9 @@
+use std::f64::consts::PI;
+
 use super::{color::Color, material::Projection};
-use crate::{model::maths::vec3::Vec3, ui::utils::misc::Value};
+use crate::{model::maths::{vec2::Vec2, vec3::Vec3}, ui::utils::misc::Value};
 use image::RgbaImage;
+use rand::Rng;
 
 #[derive(Clone, Debug)]
 pub enum TextureType {
@@ -19,18 +22,6 @@ pub enum Texture {
 }
 
 impl Texture {
-    pub fn to_string(&self) -> String {
-        match self {
-            Self::Texture(file, _) => file.to_string(),
-            Self::Value(vector, t) => match t {
-                TextureType::Float => vector.to_value().to_string(),
-                TextureType::Boolean => (vector.to_value() > 0.5).to_string(),
-                TextureType::Color => Color::from_vec3(vector).to_string(),
-                TextureType::Vector => vector.to_string(),
-            },
-        }
-    }
-
     pub fn from_vector(file: &str, default_vec: Vec3) -> Self {
         if file == "" {
             Texture::Value(default_vec, TextureType::Vector)
@@ -84,5 +75,94 @@ impl Texture {
             .min(img.height() - 1);
 
         Color::from_rgba(img.get_pixel(x, y))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TexturePattern {
+    Cosine(Vec3, Vec3, Vec3, Vec3),
+    BumpSine(f64, f64),
+    CheckerBoard(Vec3, Vec3),
+    Worley(u32, Vec3, Vec3)
+}
+
+impl TexturePattern {
+    pub fn generate(self, res_x: u32, res_y: u32) -> RgbaImage {
+        let mut img = RgbaImage::new(res_x, res_y);
+        match self {
+            TexturePattern::Cosine(u_min, u_max, v_min, v_max) => {
+                for (x, y, pixel) in img.enumerate_pixels_mut() {
+                    let u_ratio = (((x as f64 / res_x as f64) * 2. * PI - PI).cos() + 1.) / 2.0;
+                    let v_ratio = (((y as f64 / res_y as f64) * 2. * PI - PI).cos() + 1.) / 2.0;
+                    let color_u = u_min + (u_ratio * (u_max - u_min));
+                    let color_v = v_min + (v_ratio * (v_max - v_min));
+                    let final_color_vec = (color_u + color_v) / 2.;
+                    let final_color = Color::from_vec3(&final_color_vec).to_rgba();
+                    pixel.0 = final_color.0;
+                }
+            },
+            TexturePattern::BumpSine(u_variation, v_variation) => {
+                for x in 0..res_x {
+                    let u_cos = - ((x as f64 / res_x as f64) * 2. * PI - PI).sin() * u_variation;
+                    for y in 0..res_y {
+                        let v_cos =  -((y as f64 / res_y as f64) * 2. * PI - PI).sin() * v_variation;
+                        let norm = Vec3::new(-u_cos * u_variation, -v_cos * v_variation, 1.).normalize() / 2. + Vec3::new(0.5, 0.5, 0.5);
+                        img.put_pixel(x, y, Color::from_vec3(&norm).to_rgba());
+                    }
+                }
+            }
+            TexturePattern::CheckerBoard(color_a, color_b) => {
+                for (x, y, pixel) in img.enumerate_pixels_mut() {
+                    let u_color = (x as f64 / res_x as f64) < 0.5;
+                    let v_color = (y as f64 / res_y as f64) >= 0.5;
+                    if u_color != v_color {
+                        pixel.0 = Color::from_vec3(&color_a).to_rgba().0;
+                    } else {
+                        pixel.0 = Color::from_vec3(&color_b).to_rgba().0;
+                    }
+                }
+            },
+            TexturePattern::Worley(dots_number, color_a, color_b) => {
+                let mut dots = vec![];
+                for _ in 0..dots_number {
+                    let x = rand::thread_rng().gen_range((0.)..(1.) as f64);
+                    let y = rand::thread_rng().gen_range((0.)..(1.) as f64);
+
+                    dots.push(Vec2::new(x, y));
+                }
+                let mut min = 1.;
+                let mut next_min = 1.;
+                for (x, y, pixel) in img.enumerate_pixels_mut() {
+                    for dot in &dots {
+                        let mut x_dist = ((x as f64 / res_x as f64) - dot.x()).abs();
+                        if x_dist > 0.5 {
+                            x_dist = 1. - x_dist;
+                        }
+                        let mut y_dist = ((y as f64 / res_y as f64) - dot.y()).abs(); 
+                        if y_dist > 0.5 {
+                            y_dist = 1. - y_dist;
+                        }
+                        let dist = (x_dist * x_dist + y_dist * y_dist).sqrt();
+                        match dist {
+                            n if n < min => {
+                                next_min = min;
+                                min = n;
+                            },
+                            n if n >= min && n < next_min => {
+                                next_min = n;
+                            }
+                            _ => {}
+                        }
+                    }
+                    if dots.len() > 1 {
+                        let color_vec = color_a + (color_b - color_a) * ((next_min - min) / next_min).sqrt().min(1.);
+                        pixel.0 = Color::from_vec3(&color_vec).to_rgba().0;
+                    }
+                    min = 1.;
+                    next_min = 1.;
+                }
+            }
+        }
+        img
     }
 }

--- a/src/model/shapes/any.rs
+++ b/src/model/shapes/any.rs
@@ -35,10 +35,7 @@ impl Shape for Any {
         let mut t_array: Vec<f64> = Vec::new();
         
         match solution.ok() {
-            Some(t) => 
-                if t > 0.0 {
-                    t_array.push(t);
-                },
+            Some(t) => t_array.push(t),
             None => {},
         }
 

--- a/src/model/shapes/cylinder.rs
+++ b/src/model/shapes/cylinder.rs
@@ -1,5 +1,5 @@
 use super::{shape::Shape, utils::get_cross_axis};
-use std::{f64::{consts::PI, EPSILON}, sync::{Arc, RwLock}};
+use std::{f64::consts::PI, sync::{Arc, RwLock}};
 use crate::{
     model::{
         materials::material::Projection,

--- a/src/model/shapes/ellipse.rs
+++ b/src/model/shapes/ellipse.rs
@@ -32,7 +32,7 @@ impl Shape for Ellipse {
         let mut t_array: Vec<f64> = Vec::new();
 
         for t in t.unwrap() {
-            if t > 0. && self.is_inside(r.get_pos() + r.get_dir() * t) {
+            if self.is_inside(r.get_pos() + r.get_dir() * t) {
                 t_array.push(t);
             }
         }

--- a/src/model/shapes/torus.rs
+++ b/src/model/shapes/torus.rs
@@ -89,9 +89,7 @@ impl Shape for Torus {
                 let len = roots.as_ref().len();
                 let mut t = Vec::with_capacity(len);
                 for i in 0..len {
-                    if roots.as_ref()[i] > 0.0 {
-                        t.push(roots.as_ref()[i]);
-                    }
+                    t.push(roots.as_ref()[i]);
                 }
                 if t.len() > 0 {
                     return Some(t);

--- a/src/model/shapes/wireframe.rs
+++ b/src/model/shapes/wireframe.rs
@@ -180,7 +180,7 @@ impl Shape for Wireframe {
         let t1_is_wireframe = self.is_wireframe_point(&t1);
         let t2_is_wireframe = self.is_wireframe_point(&t2);
         
-        if tmin > 0.0 && tmax > 0.0 && tmin < tmax && (t1_is_wireframe || t2_is_wireframe) {
+        if tmin < tmax && (t1_is_wireframe || t2_is_wireframe) {
             if !t1_is_wireframe && t2_is_wireframe {
                 tmin = tmax;
             }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,10 +1,12 @@
 pub mod json;
 pub mod basic;
 pub mod elements;
+pub mod textures;
 
 use elements::{get_ambient, get_any, get_brick, get_camera, get_cone, get_cube, get_cubehole, get_cylinder, get_ellipse, get_helix, get_hyperboloid, get_light, get_mobius, get_nagone, get_obj, get_parallel, get_plane, get_rectangle, get_sphere, get_spot, get_torus, get_torusphere, get_triangle};
 use json::JsonValue;
 use basic::get_color_texture;
+use textures::get_texture;
 use crate::model::{materials::texture::Texture, scene::Scene};
 use std::{collections::HashMap, io::{stdout, Write}};
 
@@ -20,7 +22,7 @@ fn match_object(scene: &mut Scene, object: HashMap<String, JsonValue>) -> Result
                 "skybox" => {
                     let skybox_texture = get_color_texture(&object)?;
                     if let Texture::Texture(path, _) = &skybox_texture {
-                        scene.load_texture(path);
+                        scene.load_texture(path, None);
                     }
                     scene.set_skybox(skybox_texture);
                 }
@@ -132,6 +134,10 @@ fn match_object(scene: &mut Scene, object: HashMap<String, JsonValue>) -> Result
                     let obj = get_obj(&object)?;
                     scene.load_material_textures(obj.material());
                     scene.add_composed_element(obj);
+                }
+                "texture" => {
+                    let (name, img) = get_texture(&object)?;
+                    scene.load_texture(&name, Some(img));
                 }
                 _ => {
                     return Err(format!("Unknown type detected: {}", object_type));

--- a/src/parsing/textures.rs
+++ b/src/parsing/textures.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+use image::RgbaImage;
+
+use crate::model::{materials::texture::TexturePattern, maths::vec3::Vec3};
+
+use super::{basic::{get_number, get_string, get_vec3}, json::JsonValue};
+
+
+
+pub fn get_texture(json_obj: &HashMap<String, JsonValue>) -> Result<(String, RgbaImage), String> {
+    let pattern = get_string(&json_obj, "pattern", None)?;
+    let name = get_string(&json_obj, "name", None)?;
+    let res_x = get_number(&json_obj, "res_x", Some(0.), None, Some(500.))? as u32;
+    let res_y = get_number(&json_obj, "res_y", Some(0.), None, Some(500.))? as u32;
+    let img = match pattern.as_str() {
+        "sine" => {
+            get_sine_texture(json_obj, res_x, res_y)?
+        },
+        "worley" => {
+            get_worley_texture(json_obj, res_x, res_y)?
+        },
+        "bumpSine" => {
+            get_bump_sine(json_obj, res_x, res_y)?
+        }
+        "checkerboard" => {
+            get_checkerboard_texture(json_obj, res_x, res_y)?
+        },
+        _ => {
+            return Err(format!("The pattern {} of the texture named {} isn't a known pattern", pattern, name));
+        }
+    };
+    Ok((name, img))
+}
+
+pub fn get_sine_texture(json_obj: &HashMap<String, JsonValue>, res_x: u32, res_y: u32) -> Result<RgbaImage, String> {
+    let u_min = get_vec3(json_obj, "u_min", Some(0.), Some(255.), Some(Vec3::new(255., 255., 255.)))? / 255.;
+    let u_max = get_vec3(json_obj, "u_max", Some(0.), Some(255.), Some(Vec3::new(0., 0., 0.)))? / 255.;
+    let v_min = get_vec3(json_obj, "v_min", Some(0.), Some(255.), Some(Vec3::new(255., 255., 255.)))? / 255.;
+    let v_max = get_vec3(json_obj, "v_max", Some(0.), Some(255.), Some(Vec3::new(0., 0., 0.)))? / 255.;
+    Ok(TexturePattern::Cosine(u_min, u_max, v_min, v_max).generate(res_x, res_y))
+}
+
+pub fn get_bump_sine(json_obj: &HashMap<String, JsonValue>, res_x: u32, res_y: u32) -> Result<RgbaImage, String> {
+    let u_variation = get_number(json_obj, "u_variation", None, None, Some(1.))?;
+    let v_variation = get_number(json_obj, "v_variation", None, None, Some(1.))?;
+    Ok(TexturePattern::BumpSine(u_variation, v_variation).generate(res_x, res_y))
+}
+
+pub fn get_checkerboard_texture(json_obj: &HashMap<String, JsonValue>, res_x: u32, res_y: u32) -> Result<RgbaImage, String> {
+    let color_a = get_vec3(json_obj, "color_a", Some(0.), Some(255.), Some(Vec3::new(255., 255., 255.)))? / 255.;
+    let color_b = get_vec3(json_obj, "color_b", Some(0.), Some(255.), Some(Vec3::new(0., 0., 0.)))? / 255.;
+    Ok(TexturePattern::CheckerBoard(color_a, color_b).generate(res_x, res_y))
+}
+
+pub fn get_worley_texture(json_obj: &HashMap<String, JsonValue>, res_x: u32, res_y: u32) -> Result<RgbaImage, String> {
+    let dots = get_number(json_obj, "dots", Some(1.), None, Some(30.))? as u32;
+    let color_a = get_vec3(json_obj, "color_a", Some(0.), Some(255.), Some(Vec3::new(255., 255., 255.)))? / 255.;
+    let color_b = get_vec3(json_obj, "color_b", Some(0.), Some(255.), Some(Vec3::new(0., 0., 0.)))? / 255.;
+    Ok(TexturePattern::Worley(dots, color_a, color_b).generate(res_x, res_y))
+}

--- a/src/render/settings.rs
+++ b/src/render/settings.rs
@@ -102,7 +102,7 @@ impl Displayable for Settings {
             |value, scene| {
                 let mut scene = scene.write().unwrap();
                 if let Texture::Texture(path, _) = &value {
-                    scene.load_texture(&path);
+                    scene.load_texture(&path, None);
                 }
                 scene.set_skybox(value);
                 scene.set_dirty(true);

--- a/src/ui/prefabs/material_ui.rs
+++ b/src/ui/prefabs/material_ui.rs
@@ -18,7 +18,7 @@ pub fn get_material_ui(element: &Element, ui: &mut UI, _scene: &Arc<RwLock<Scene
     material_category.add_element(get_texture_ui("Color", element.material().color(), Box::new(move |texture, scene| {
         let mut scene_write = scene.write().unwrap();
         if let Texture::Texture(file, _) = &texture {
-            scene_write.load_texture(file);
+            scene_write.load_texture(file, None);
         }
         if let Some(element) = scene_write.composed_element_mut_by_element_id(id_element) {
             element.material_mut().set_color(texture);


### PR DESCRIPTION
Major :
- Added procedurally generated textures :
    - In parsing : A block of type texture needs to be added, with parameters res_x(500), res_y(500), a name to be referenced later in the parsing instead of a file, and a type among the following :
        - "checkerboard" : Has color_a(white) and color_b(black) as optional parameters
        - "sine" : Has u_min(white), u_max(black), v_min(white), v_max(black) as optional parameters, all respectively the color the textures takes when sin(u) and sin(v) are -1 or 1, or a mix in between
        - "bumpSine" : A normal map producing waves in either direction(u or v), or both. Takes u_variation and v_variation as optional parameters, those being the depth change depending on the output of the sine function.
        - "worley" : Generated cellular noise, takes as optional parameters dots(30) being the number of "cells" in the texture, color_a(black) being the color of the border between cells, and color_b(white) being the color the cells themselves.
    - No corresponding UI has been provided. When textures are already applied by parsing, you see the chosen name as the texture, but you can't select a new one in the UI.

Minor :
- Fixed some native shapes not returning all intersections distances, whether they're negative or not, as is needed since the refraction implementation to determine what entering refraction indice we must use.