### PR TITLE
Revert of the changes made by #94 + Proper fix + Reduction of the blinding effect in phong

### DIFF
--- a/src/render/lighting/lighting_phong.rs
+++ b/src/render/lighting/lighting_phong.rs
@@ -20,7 +20,7 @@ pub fn phong_lighting_from_hit(scene: &Scene, hit: &Option<Hit>, ray: &Ray) -> C
 				}
 				let specular = light.light().get_specular(&hit, &fake_ray);
 				let diffuse = light.light().get_diffuse(&hit);
-				cam_color += diffuse + specular;
+				cam_color += &diffuse * &diffuse + specular;
 				cam_color = cam_color * Color::from_vec3(&throughput);
 			}
 		}
@@ -36,7 +36,7 @@ pub fn phong_lighting_from_hit(scene: &Scene, hit: &Option<Hit>, ray: &Ray) -> C
 				color = color * Color::from_vec3(&throughput);
 			}
 		}
-		if hit.opacity() < 1. - f64::EPSILON {
+		if hit.opacity() < f64::EPSILON {
 			let light_through = get_lighting_from_ray(scene, &Ray::new(hit.pos().clone() + *ray.get_dir() * BOUNCE_OFFSET, ray.get_dir().clone(), ray.get_depth()));
 			color = color * hit.opacity() + hit.color() * light_through * (1. - hit.opacity());
 		}

--- a/src/render/lighting/lighting_phong.rs
+++ b/src/render/lighting/lighting_phong.rs
@@ -14,7 +14,7 @@ pub fn phong_lighting_from_hit(scene: &Scene, hit: &Option<Hit>, ray: &Ray) -> C
 		let hit: Hit<'_> = Hit::new(&elem, 0., *scene.camera().pos(), fake_ray.get_dir(), scene.textures(), vec![0.]);
 		for light in scene.lights() {
 			let throughput = light.light().throughput(scene, &hit);
-			if throughput.length() > -f64::EPSILON {
+			if throughput.length() > f64::EPSILON {
 				if ray.debug {
 					fake_ray.debug = true;
 				}
@@ -26,21 +26,17 @@ pub fn phong_lighting_from_hit(scene: &Scene, hit: &Option<Hit>, ray: &Ray) -> C
 		}
 	}
 	if let Some(hit) = hit {
-		let mut colors: Vec<Color> = vec![];
 		let mut color: Color = scene.ambient_light().color() * scene.ambient_light().intensity() * hit.color();
 	
 		for light in scene.lights() {
 			let throughput = light.light().throughput(scene, &hit);
-			if throughput.length() > -f64::EPSILON {
+			if throughput.length() > f64::EPSILON {
 				color += light.light().get_diffuse(&hit) * hit.color();
 				color += light.light().get_specular(&hit, ray);
 				color = color * Color::from_vec3(&throughput);
-				colors.push(color);
-				color = scene.ambient_light().color() * scene.ambient_light().intensity() * hit.color();
 			}
 		}
-		color = colors.iter().fold(Color::new(0., 0., 0.), |acc, x| acc + x);
-		if hit.opacity() < f64::EPSILON {
+		if hit.opacity() < 1. - f64::EPSILON {
 			let light_through = get_lighting_from_ray(scene, &Ray::new(hit.pos().clone() + *ray.get_dir() * BOUNCE_OFFSET, ray.get_dir().clone(), ray.get_depth()));
 			color = color * hit.opacity() + hit.color() * light_through * (1. - hit.opacity());
 		}


### PR DESCRIPTION
Minor :
- Revert of the multiple changes made to the phong lighting to fix shadows taking only one light into account
- Fix of the initial problem
- Reduced the strength of the diffuse component in the phong blinding effect