### PR TITLE
Multiple bugfixes and small QOL features

### DIFF
--- a/scenes/metalrough.json
+++ b/scenes/metalrough.json
@@ -1,5 +1,9 @@
 [
     {
+        "type": "viewmode",
+        "value": "global"
+    },
+    {
         "type": "sphere",
         "pos": [-2.5, 2.5, 2],
         "dir": [0, 1, 0],
@@ -83,7 +87,7 @@
         "dir_w": [0, 0, 1],
         "length": 10,
         "width": 30,
-        "color": [255, 50, 50],
+        "color": [255, 120, 120],
         "emissive": 1
     },
     {
@@ -93,7 +97,7 @@
         "dir_w": [0, 0, 1],
         "length": 10,
         "width": 30,
-        "color": [50, 255, 50],
+        "color": [120, 255, 120],
         "emissive": 1
     },
 

--- a/scenes/tests/refraction.json
+++ b/scenes/tests/refraction.json
@@ -82,13 +82,5 @@
         "displacement": "MetalWalkway007_1K-JPG/MetalWalkway007_1K-JPG_Displacement.jpg",
         "u_scale": 3,
         "v_scale": 3
-    },
-    // {
-    //     "type": "obj",
-    //     "pos": [0, -2, -4],
-    //     "scale": 1,
-    //     "dir": [0, 1, 0],
-    //     "file": "obj/knight.obj",
-    //     "color": [150, 125, 1]
-    // }
+    }
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ const SCREEN_HEIGHT_U32: u32 = SCREEN_HEIGHT as u32;
 const SCENE_FOLDER: &str = "scenes";
 const TEXTURE_FOLDER: &str = "textures";
 const DEFAULT_SKYBOX_TEXTURE: &str = "skybox/skybox_night.jpg";
+const MAX_OPENED_SCENES: usize = 5;
 
 /************* Camera **************/
 const STEP: f64 = 0.2;

--- a/src/model/shapes/capped_cylinder.rs
+++ b/src/model/shapes/capped_cylinder.rs
@@ -227,7 +227,7 @@ impl Shape for CappedCylinder {
                         }
                     }
                 }),
-                true, None, None));
+                false, None, None));
             category.add_element(get_vector_ui(cylinder.dir.clone(), "Direction", "dir", &ui.uisettings_mut(),
                 Box::new(move |_, value, context, _| {
                     let scene = match context.active_scene {

--- a/src/model/shapes/cone.rs
+++ b/src/model/shapes/cone.rs
@@ -153,7 +153,7 @@ impl Shape for Cone {
                         }
                     }
                 }),
-                true, None, None));
+                false, None, None));
             category.add_element(get_vector_ui(cone.dir.clone(), "Direction", "dir", &ui.uisettings_mut(),
                 Box::new(move |_, value, context, _| {
                     let scene = match context.active_scene {

--- a/src/model/shapes/cylinder.rs
+++ b/src/model/shapes/cylinder.rs
@@ -140,7 +140,7 @@ impl Shape for Cylinder {
                         }
                     }
                 }),
-                true, None, None));
+                false, None, None));
             category.add_element(get_vector_ui(cylinder.dir.clone(), "Direction", "dir", &ui.uisettings_mut(),
                 Box::new(move |_, value, context, _| {
                     let scene = match context.active_scene {

--- a/src/model/shapes/plane.rs
+++ b/src/model/shapes/plane.rs
@@ -176,7 +176,7 @@ impl Shape for Plane {
                         }
                     }
                 }),
-                true, None, None));
+                false, None, None));
             category.add_element(get_vector_ui(plane.dir.clone(), "Direction", "dir", &ui.uisettings_mut(),
                 Box::new(move |_, value, context, _| {
                     let scene = match context.active_scene {

--- a/src/model/shapes/triangle.rs
+++ b/src/model/shapes/triangle.rs
@@ -148,7 +148,7 @@ impl Shape for Triangle {
                     }
                 }
             }),
-            true, None, None));
+            false, None, None));
             category.add_element(get_vector_ui(triangle.b.clone(), "Point B", "pB", &ui.uisettings_mut(), 
             Box::new(move |_, value, context, _| {
                     let scene = match context.active_scene {
@@ -189,7 +189,7 @@ impl Shape for Triangle {
                     }
                 }
             }),
-            true, Some(-1.), Some(1.)));
+            false, Some(-1.), Some(1.)));
             category.add_element(get_vector_ui(triangle.c.clone(), "Point C", "pC", &ui.uisettings_mut(), 
             Box::new(move |_, value, context, _| {
                     let scene = match context.active_scene {
@@ -230,7 +230,7 @@ impl Shape for Triangle {
                     }
                 }
             }),
-            true, Some(-1.), Some(1.)));
+            false, Some(-1.), Some(1.)));
         }
         category
     }

--- a/src/model/shapes/wireframe.rs
+++ b/src/model/shapes/wireframe.rs
@@ -1,5 +1,5 @@
 use super::{aabb::Aabb, shape::Shape};
-use std::sync::{Arc, RwLock};
+use std::{process::exit, sync::{Arc, RwLock}};
 use crate::{
     model::{
         materials::material::Projection,
@@ -274,7 +274,8 @@ impl Shape for Wireframe {
             return Vec3::new(0.0, 0.0, 1.0);
         } else {
             // DEBUG
-            panic!("Error: hit_position is not on the AABB.\n");
+            println!("Error: hit_position is not on the AABB.\n");
+            exit(1)
         }
     }
 

--- a/src/render/lighting/lighting_real.rs
+++ b/src/render/lighting/lighting_real.rs
@@ -30,7 +30,7 @@ pub fn fresnel_reflect_ratio(n1: f64, n2: f64, norm: &Vec3, ray: &Vec3, reflecti
     let x = 1.0 - cos_x;
     let ret = r0 + (1.0 - r0) * x.powf(5.);
     // adjust reflect multiplier for object reflectivity
-    reflectivity * ret
+    reflectivity + (1.0 - reflectivity) * ret
 }
 
 pub fn get_refraction_indices(hit: &Hit, ray: &Ray) -> (f64, f64) {

--- a/src/render/settings.rs
+++ b/src/render/settings.rs
@@ -1,12 +1,14 @@
+use image::Rgba;
+
 use crate::{
     display::{anaglyph::Coloring, filters::ColorFilter}, model::{
         materials::color::Color,
         maths::vec3::Vec3, objects::lights::parallel_light::ParallelLight,
     }, ui::{
         uielement::{Category, UIElement}, uisettings::UISettings, utils::{
-            misc::{ElemType, Property, Value}, ui_utils::UIContext, Displayable
+            misc::{ElemType, Property, Value}, style::StyleBuilder, ui_utils::UIContext, Displayable
         }
-    }, ANAGLYPH_OFFSET_X, ANAGLYPH_OFFSET_Y, ANTIALIASING, DEFAULT_SKYBOX_TEXTURE, DISPLACEMENT, MAX_DEPTH, MAX_ITERATIONS, PLANE_DISPLACED_DISTANCE, PLANE_DISPLACEMENT_STEP, SPHERE_DISPLACED_DISTANCE, SPHERE_DISPLACEMENT_STEP, VIEW_MODE
+    }, ANAGLYPH_OFFSET_X, ANAGLYPH_OFFSET_Y, ANTIALIASING, DEFAULT_SKYBOX_TEXTURE, DISPLACEMENT, MAX_DEPTH, MAX_ITERATIONS, PLANE_DISPLACED_DISTANCE, PLANE_DISPLACEMENT_STEP, SCENE_TOOLBAR, SETTINGS, SPHERE_DISPLACED_DISTANCE, SPHERE_DISPLACEMENT_STEP, VIEW_MODE
 };
 
 #[derive(Debug, Clone)]
@@ -443,6 +445,16 @@ impl Displayable for Settings {
             ElemType::Category(category),
             settings,
         );
+        category.on_click = Some(Box::new(move |_element,_scene, ui| {
+            let settings = ui.uisettings().clone();
+            ui.destroy_box(SETTINGS);
+            if let Some(elem) = ui.get_element_mut(format!("{}.row.{}", SCENE_TOOLBAR, SETTINGS)) {
+                elem.set_style(StyleBuilder::from_existing(&elem.style, &settings)
+                    .bg_color(Some(Rgba([200, 200, 200, 255])))
+                    .build()
+                );
+            }
+        }));
 
         category.add_element(get_viewmode_ui(settings));
         category.add_element(get_filter_ui(settings));

--- a/src/ui/prefabs/file_ui.rs
+++ b/src/ui/prefabs/file_ui.rs
@@ -1,4 +1,4 @@
-use std::{fs::read_dir, io::Result, path::{self, Path}};
+use std::{fs::read_dir, io::Result, path::{self, Path}, process::exit};
 
 use image::Rgba;
 use crate::ui::{
@@ -190,5 +190,6 @@ pub fn get_file_box(default_folder: String, box_name: String, submit: FnSubmitVa
         })));
         return file_box;
     }
-    panic!("Problem opening files");
+    println!("Please reopen the program from the main folder root.");
+    exit(1);
 }

--- a/src/ui/prefabs/file_ui.rs
+++ b/src/ui/prefabs/file_ui.rs
@@ -163,6 +163,9 @@ fn create_value_element(settings: &UISettings, id: &str) -> UIElement {
 pub fn get_file_box(default_folder: String, box_name: String, submit: FnSubmitValue, settings: &UISettings, initial_value: String) -> UIBox {
     let mut file_box =  UIBox::new("file_box", BoxPosition::Center, settings.gui_width, settings);
     let mut cat = UIElement::new(&box_name, "cat_file", ElemType::Category(Category::default()), settings);
+    cat.on_click = Some(Box::new(move |_element,_scene, ui| {
+        ui.destroy_box("file_box");
+    }));
     let mut value_element = create_value_element(settings, "value");
     
     let file_ui = create_files_ui(&mut value_element, &mut cat, &default_folder, settings, initial_value, "file_box.cat_file".to_string());

--- a/src/ui/prefabs/material_ui.rs
+++ b/src/ui/prefabs/material_ui.rs
@@ -1,7 +1,7 @@
 use super::texture_ui::get_texture_ui;
 use std::sync::{Arc, RwLock};
 use crate::{
-    model::{materials::texture::Texture, maths::vec3::Vec3, scene::Scene, element::Element},
+    model::{element::Element, materials::texture::{Texture, TextureType}, maths::vec3::Vec3, scene::Scene},
     ui::{
         ui::UI,
         uielement::{Category, UIElement},
@@ -39,7 +39,7 @@ pub fn get_material_ui(element: &Element, ui: &mut UI, _scene: &Arc<RwLock<Scene
         } else if let Some(element) = scene_write.element_mut_by_id(id_element) {
             element.material_mut().set_displacement(texture);
         }
-    }), ui.uisettings(), true, true, None, None, None));
+    }), ui.uisettings(), true, true, None, None, Some(Texture::Value(Vec3::from_value(0.), TextureType::Float))));
 
     //Norm variation
     let norm_variation = get_texture_ui("Norm", element.material().norm(), Box::new(move |texture, scene| {
@@ -52,7 +52,7 @@ pub fn get_material_ui(element: &Element, ui: &mut UI, _scene: &Arc<RwLock<Scene
         } else if let Some(element) = scene_write.element_mut_by_id(id_element) {
             element.material_mut().set_norm(texture);
         }
-    }), ui.uisettings(), true, true, None, None, Some(Vec3::new(0., 0., 1.)));
+    }), ui.uisettings(), true, true, None, None, Some(Texture::Value(Vec3::new(0., 0., 1.0), TextureType::Vector)));
     material_category.add_element(norm_variation);
 
     //Metalness

--- a/src/ui/prefabs/texture_ui.rs
+++ b/src/ui/prefabs/texture_ui.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 
-pub fn get_texture_ui(name: &str, texture: &Texture, submit: Box<dyn Fn(Texture, &Arc<RwLock<Scene>>)>, settings: &UISettings, file: bool, only_file: bool, min: Option<f64>, max: Option<f64>, only_file_default: Option<Vec3>) -> UIElement {
+pub fn get_texture_ui(name: &str, texture: &Texture, submit: Box<dyn Fn(Texture, &Arc<RwLock<Scene>>)>, settings: &UISettings, file: bool, only_file: bool, min: Option<f64>, max: Option<f64>, only_file_default: Option<Texture>) -> UIElement {
     let mut category = UIElement::new(name, name, ElemType::Category(Category::collapsed()), settings);
     
 
@@ -71,12 +71,12 @@ pub fn get_texture_ui(name: &str, texture: &Texture, submit: Box<dyn Fn(Texture,
                                         }
                                     }
                                 } else if only_file {
-                                    if let Some(default) = only_file_default {
+                                    if let Some(default) = only_file_default.clone() {
                                         let scene = match context.active_scene {
                                             Some(active_scene_index) => context.scene_list.get(&active_scene_index).unwrap(),
                                             None => return,
                                         };
-                                        submit(Texture::from_vector("", default), scene);
+                                        submit(default, scene);
                                     }
                                 } else {
                                     let scene = match context.active_scene {

--- a/src/ui/ui_setup/scene_ui.rs
+++ b/src/ui/ui_setup/scene_ui.rs
@@ -44,8 +44,8 @@ pub fn change_scene(context: &mut UIContext, ui: &mut UI, render_id: Option<usiz
 pub fn add_scene_to_ui(ui: &mut UI, _context: &mut UIContext, id: usize, scene_path: &str) {
     let uisettings = ui.uisettings().clone();
     if let Some(row) = ui.get_element_mut(TOOLBAR.to_string() + ".row") {
-        let scene_name = scene_path.split("/").last().unwrap_or_default();
-        let mut btn_scene = UIElement::new(scene_name, &format!("{}.scene_{}", row.reference.clone(), id), ElemType::Button(Some(Box::new(
+        let scene_name = scene_path.split("/").last().unwrap_or_default().to_string();
+        let mut btn_scene = UIElement::new(&scene_name, &format!("{}.scene_{}", row.reference.clone(), id), ElemType::Button(Some(Box::new(
             move |element, context, ui| {
                 if context.active_scene.is_none() || context.active_scene.unwrap() != id {
                     change_scene(context, ui, Some(id), element);

--- a/src/ui/ui_setup/scene_ui.rs
+++ b/src/ui/ui_setup/scene_ui.rs
@@ -1,5 +1,5 @@
 use image::Rgba;
-use crate::{display::{mainloop::load_scene, ui_setup::{setup_objects_ui, setup_settings}}, render::render_thread::UIOrder, ui::{prefabs::file_ui::get_file_box, ui::UI, uibox::{BoxPosition, UIBox}, uielement::UIElement, uisettings::UISettings, utils::{misc::{ElemType, Value}, style::{Style, StyleBuilder}, ui_utils::UIContext}}, ELEMENT, OBJECTS, SCENE_FOLDER, SCENE_TOOLBAR, SCREEN_WIDTH_U32, SETTINGS, TOOLBAR};
+use crate::{display::{mainloop::load_scene, ui_setup::{setup_objects_ui, setup_settings}}, render::render_thread::UIOrder, ui::{prefabs::file_ui::get_file_box, ui::UI, uibox::{BoxPosition, UIBox}, uielement::UIElement, uisettings::UISettings, utils::{misc::{ElemType, Value}, style::{Style, StyleBuilder}, ui_utils::UIContext}}, ELEMENT, MAX_OPENED_SCENES, OBJECTS, SCENE_FOLDER, SCENE_TOOLBAR, SCREEN_WIDTH_U32, SETTINGS, TOOLBAR};
 
 
 pub fn change_scene(context: &mut UIContext, ui: &mut UI, render_id: Option<usize>, element: Option<&mut UIElement>) {
@@ -61,7 +61,7 @@ pub fn add_scene_to_ui(ui: &mut UI, _context: &mut UIContext, id: usize, scene_p
     }
 }
 
-pub fn setup_scene_options(ui: &mut UI, context: &UIContext, render_id: usize) {
+pub fn setup_scene_options(ui: &mut UI, _context: &UIContext, _render_id: usize) {
     ui.destroy_box(SCENE_TOOLBAR);
 
     let mut toolbar_box = UIBox::new(SCENE_TOOLBAR, BoxPosition::TopLeft(20, 0), SCREEN_WIDTH_U32, ui.uisettings());
@@ -133,29 +133,6 @@ pub fn setup_scene_options(ui: &mut UI, context: &UIContext, render_id: usize) {
                 }
             }
     }))), ui.uisettings());
-
-    
-    let text = match context.scene_list.get(&render_id).unwrap().read().unwrap().paused() {
-        true => "Start",
-        false => "Pause"
-    };
-    
-    let btn_pause = UIElement::new(text, "pause", ElemType::Button(Some(Box::new(
-        move |elem, context, _| {
-            if let Some(elem) = elem {
-                let mut scene = context.scene_list.get(&render_id).unwrap().write().unwrap();
-            if scene.paused() {
-                elem.text = "Pause".to_string();
-                context.transmitter.send(UIOrder::SceneStart(render_id)).unwrap();
-                scene.set_paused(false);
-                
-            } else {
-                elem.text = "Start".to_string();
-                context.transmitter.send(UIOrder::ScenePause(render_id)).unwrap();
-                scene.set_paused(true);
-            }
-        }
-    }))), ui.uisettings());
     
     let row_reference = row.reference.clone();
     
@@ -168,14 +145,29 @@ pub fn setup_scene_options(ui: &mut UI, context: &UIContext, render_id: usize) {
                 ui.remove_element_by_reference(format!("{}.{}.scene_{}",TOOLBAR, row_reference, id));
                 
                 context.active_scene = None;
-                change_scene(context,ui, context.previous_active_scene.clone(), None);
+                let next_scene = match context.previous_active_scene.is_none() {
+                    false => {
+                        context.previous_active_scene.clone()
+                    },
+                    true if context.scene_list.len() > 0 => {
+                        let mut render_id = None;
+                        for (id, _) in &context.scene_list {
+                            render_id = Some(*id);
+                            break;
+                        }
+                        render_id
+                    }
+                    _ => {
+                        None
+                    }
+                };
+                change_scene(context,ui, next_scene, None);
                 elem.style_mut().visible = false;
             }
         }))), ui.uisettings());
         
     row.add_element(btn_settings);
     row.add_element(btn_objects);
-    row.add_element(btn_pause);
     row.add_element(btn_close);
 
     toolbar_box.add_elements(vec![row]);
@@ -196,16 +188,20 @@ pub fn setup_scene_toolbar(ui: &mut UI, _context: &UIContext) {
     row.style_mut().padding_left = 0;
     row.style_mut().padding_right = 0;
     row.style_mut().margin = 0;
-    let mut btn_open_scene = UIElement::new("New scene", "open_scene", ElemType::Button(Some(Box::new(
-        move |_, _, ui| {
-            let file_box = get_file_box(SCENE_FOLDER.to_string(), "open_scene_box".to_string(), Box::new(move |_, value, context, ui| {
-                if let Value::Text(scene_path) = value {
-                    load_scene(scene_path.as_str(), context, ui);
-                }
-            }), ui.uisettings(), "".to_string());
-            let box_reference = file_box.reference.clone();
-            ui.add_box(file_box);
-            ui.set_active_box(box_reference);
+    let mut btn_open_scene = UIElement::new("Open scene", "open_scene", ElemType::Button(Some(Box::new(
+        move |_, context, ui| {
+            if context.scene_list.len() < MAX_OPENED_SCENES {   
+                let file_box = get_file_box(SCENE_FOLDER.to_string(), "Scene list".to_string(), Box::new(move |_, value, context, ui| {
+                    if let Value::Text(scene_path) = value {
+                        load_scene(scene_path.as_str(), context, ui);
+                    }
+                }), ui.uisettings(), "".to_string());
+                let box_reference = file_box.reference.clone();
+                ui.add_box(file_box);
+                ui.set_active_box(box_reference);
+            } else {
+                println!("Too much scenes currently opened, close one before attempting to open another one.");
+            }
     }))), ui.uisettings());
 
     btn_open_scene.set_style(get_unselected_scene_tab_style(ui.uisettings(), true));

--- a/src/ui/uibox.rs
+++ b/src/ui/uibox.rs
@@ -17,7 +17,6 @@ pub struct UIBox {
     pub offset: u32,
     pub max_height: u32,
     pub scrollable: bool,
-    // pub borders: Option<(Color, usize)>,
     pub elems: Vec<UIElement>,
     pub reference: String,
     pub style: Style,

--- a/src/ui/uielement.rs
+++ b/src/ui/uielement.rs
@@ -1,3 +1,4 @@
+
 use super::{
     ui::UI,
     uisettings::UISettings,
@@ -32,18 +33,6 @@ impl UIElement {
             on_click: None
         }
     }
-
-    // pub fn add_element_to_front(&mut self, elem: UIElement) {
-    //     if let ElemType::Category(cat) = &mut self.elem_type {
-    //         let mut new_elems = vec![elem];
-    //         new_elems.append(&mut cat.elems);
-    //         cat.elems = new_elems;
-    //     } else if let ElemType::Row(elems) = &mut self.elem_type {
-    //         let len = elems.len();
-
-    //         elems.push(elem);
-    //     }
-    // }
 
     pub fn add_element(&mut self, elem: UIElement) {
         if let ElemType::Category(cat) = &mut self.elem_type {

--- a/src/ui/utils/draw_utils.rs
+++ b/src/ui/utils/draw_utils.rs
@@ -5,18 +5,33 @@ use rusttype::{Font, Scale};
 
 pub fn draw_element_text(
     img: &mut RgbaImage,
-    text: String,
-    pos: (i32, i32),
+    mut text: String,
+    mut pos: (i32, i32),
     size: (u32, u32),
     style: &Style,
 ) {
+    if pos.0 < 0 {
+        pos.0 = 0;
+    }
+    if pos.1 < 0 {
+        pos.1 = 0;
+    }
     let pos = (pos.0 as u32, pos.1 as u32);
     draw_background(img, pos, size, style);
 
     let mut padding_left = style.padding_left;
     if style.text_center {
-        let text_width = style.font_size() as u32 / 2 * (text.len() as u32 + 1);
         let available_width = size.0 - style.padding_left - style.padding_right;
+        let text_allowed_len = available_width as usize / (style.font_size() as usize / 2) - 1;
+        if text.len() > text_allowed_len {
+            if text_allowed_len < 2 {
+                text = "".to_string();
+            } else {
+                text.truncate(text_allowed_len - 2);
+                text = text + ".."
+            }
+        }
+        let text_width = style.font_size() as u32 / 2 * (text.len() as u32 + 1);
         padding_left += (available_width - text_width) / 2;
     }
     
@@ -224,7 +239,7 @@ pub fn get_size(text: &String, style: &Style, max_size: (u32, u32)) -> (u32, u32
     if wanted_width > width {
         width = wanted_width;
     }
-    if width > max_size.0 {
+    if width > max_size.0 && style.multilines {
         let lines = split_in_lines(text.clone(), style.width, style);
         height += (style.font_size() as u32 + style.padding_bot) * lines.len() as u32;
     }

--- a/src/ui/utils/style.rs
+++ b/src/ui/utils/style.rs
@@ -22,7 +22,8 @@ pub struct Style {
     pub padding_top: u32,
     pub padding_bot: u32,
     pub text_center: bool,
-    pub margin: u32
+    pub margin: u32,
+    pub multilines: bool
 }
 pub trait Formattable {
     fn base_style(&self, settings: &UISettings) -> Style {
@@ -55,6 +56,7 @@ impl StyleBuilder {
             .border_size(2)
             .border_color(Some(Rgba([30, 30, 30, 255])))
             .border_radius(3)
+            .multilines(false)
     }
     pub fn padding_left(mut self, padding_left: u32) -> Self {
         self.style.padding_left = padding_left;
@@ -144,6 +146,10 @@ impl StyleBuilder {
         self.style.margin = margin;
         self
     }
+    pub fn multilines(mut self, multilines: bool) -> Self {
+        self.style.multilines = multilines;
+        self
+    }
     pub fn build(self) -> Style {
         self.style
     }
@@ -187,7 +193,8 @@ impl Style {
             visible: true,
             disabled: false,
             fill_width: false,
-            margin: settings.margin
+            margin: settings.margin,
+            multilines: true
         }
     }
 


### PR DESCRIPTION
- Added a limit to the number of concurrently opened scenes
- Fixed a bug when closing multiple scenes in a row
- Fixed a bug where the displacement could not be removed from some elements in the UI
- Fixed a bug when scrolling in the file box
- Inversed the UI scroll properly
- Instead of closing the program, ECHAP now just closes non-mandatory UIBoxes, like the scene settings, file box, objects, or element box. You now need to manually close it, to avoid unwanted closing.
- Fixed the formula for reflectivity application in the fresnel factor.
- Fixed the labels for some element's position in the UI, showing RGB instead of XYZ
- Fixed some problems when scene configuration file name was too long for the UI
- Changed some panic! behavior into a proper exit when it was warranted